### PR TITLE
fast_jsonapiを用いてJSON:API以外の形式で無理やり返せるようにするのを試す

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,6 @@
+class UsersController < ApplicationController
+  def index
+    @users = User.all
+    render json: @users
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.all
-    render json: @users
+    users = User.all
+    render json: ::UsersSerializer.new(users).serialized_json
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_many :posts
+end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,3 @@
+class ApplicationSerializer
+  include FastJsonapi::ObjectSerializer
+end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,3 +1,29 @@
 class ApplicationSerializer
   include FastJsonapi::ObjectSerializer
+
+  private
+
+  def hash_for_collection
+    # dataのattributesまでのネストを省略して、{ attribute: value }の配列を返す
+    # ex: [{ somthing: true }]
+    hash = super
+    return hash[:data].map { |item| item[:attributes] } unless @params[:key_is_id]
+
+    # {何かのid値: obj}で返したいときはparamsにkey_is_id: trueを指定する
+    # ex:
+    # {
+    #   0: {somthing: true},
+    #   1: {somthing: true}
+    # }
+    hash[:data].each_with_object({}) do |item, result|
+      result[item[:id]] = item[:attributes]
+    end
+  end
+
+  # dataのattributesまでのネストを省略して、{ attribute: value }を返す
+  # ex: { somthing: true }
+  def hash_for_one_record
+    hash = super
+    hash[:data][:attributes]
+  end
 end

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,0 +1,6 @@
+class UsersSerializer < ApplicationSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attribute :name
+  has_many :posts
+end

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,6 +1,13 @@
 class UsersSerializer < ApplicationSerializer
   include FastJsonapi::ObjectSerializer
 
+  class PostsSerializer < ApplicationSerializer
+    attributes :title, :content
+  end
+
   attribute :name
-  has_many :posts
+
+  attribute :posts do |record|
+    PostsSerializer.new(record.posts).serialized_json
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :users, only: :index
 end

--- a/db/migrate/20200118124429_create_user.rb
+++ b/db/migrate/20200118124429_create_user.rb
@@ -1,0 +1,13 @@
+class CreateUser < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+    end
+
+    create_table :posts do |t|
+      t.references :user, null: false
+      t.string :title, null: false
+      t.string :content, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_01_18_124429) do
+
+  create_table "posts", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "title", null: false
+    t.string "content", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+users = User.create([{ name: 'hoge' }, { name: 'huga' }])
+
+users.each do |user|
+  Post.create(user: user, title: '1st post', content: "hello world by #{user.name}")
+end


### PR DESCRIPTION
## JSON:API形式
```
{
    "data": [
        {
            "id": "1",
            "type": "users",
            "attributes": {
                "name": "hoge",
                "posts": "{\"data\":[{\"id\":\"1\",\"type\":\"posts\",\"attributes\":{\"title\":\"1st post\",\"content\":\"hello world by hoge\"}}]}"
            }
        },
        {
            "id": "2",
            "type": "users",
            "attributes": {
                "name": "huga",
                "posts": "{\"data\":[{\"id\":\"2\",\"type\":\"posts\",\"attributes\":{\"title\":\"1st post\",\"content\":\"hello world by huga\"}}]}"
            }
        }
    ]
}
```

## カスタマイズした形式
クライアントサイドからの要望に答えて、ネストを浅くし他形式にする
```
[
    {
        "name": "hoge",
        "posts": "[{\"title\":\"1st post\",\"content\":\"hello world by hoge\"}]"
    },
    {
        "name": "huga",
        "posts": "[{\"title\":\"1st post\",\"content\":\"hello world by huga\"}]"
    }
]
```